### PR TITLE
Address AS-146: add additional display information to the Request form

### DIFF
--- a/public/assets/recaptcha.css
+++ b/public/assets/recaptcha.css
@@ -2,3 +2,8 @@
 .recaptcha_error {
   display: none; 
 }
+
+/* remove list styling for the note */
+.request-additional-notes {
+  list-style-type: none;
+}

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,6 +27,9 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
+    <ul class="request-additional-notes">
+      <%= t('request.note_additional').html_safe %>
+    </ul>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>

--- a/public/views/shared/_request_form.html.erb
+++ b/public/views/shared/_request_form.html.erb
@@ -27,9 +27,11 @@
       <%= label_tag(:note, t('request.note'),  :class => 'sr-only') %>
       <%= text_area_tag :note, nil, :rows=> "3", :cols => "25", :placeholder => t('request.note'), :class => 'form-control' %>
     </div>
-    <ul class="request-additional-notes">
-      <%= t('request.note_additional').html_safe %>
-    </ul>
+    <div>
+      <ul class="request-additional-notes">
+        <%= t('request.note_additional').html_safe %>
+      </ul>
+    </div>
     <div class="form-group honeypot">
       <span class="aria-hidden">
         <%= label_tag :comment %>


### PR DESCRIPTION
**JIRA ticket:** [AS-146](https://jirautk.atlassian.net/browse/AS-146)

# What: #
This PR modifies the recaptcha `_request_form.html.erb`, adding an unordered list that displays the `note_additional` data from our local plugin. 

# Notes: #
I have no idea if this was the best way to accomplish this. Please let me know if you see anything incredibly dumb.

# How to Test: #
We don't have a super efficient way of testing this right now. You can see the practical results on `https://scoutdev.lib.utk.edu/repositories/2/resources/4036`. Thanks for any feedback, questions, comments, etc.

# Interested Parties #
@markpbaggett @sfunk3 